### PR TITLE
Add links and twitter to group page

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -169,4 +169,3 @@
    - carl_ab_pearson
    - kiesha_prem
    - thibaut_jombart
-   - ruwan_ratnayake

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,93 +1,144 @@
 - id: adam_kucharski
   name: Adam J Kucharski
   email: adam.kucharski@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/kucharski.adam
+  twitter: adamjkucharski
 - id: seb_funk
   name: Sebastian Funk
   email: sebastian.funk@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/funk.sebastian
+  twitter: sbfnk
 - id: roz_eggo
   name: Rosalind Eggo
   email: r.eggo@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/eggo.rosalind
+  twitter: rozeggo
 - id: petra_klepac
   name: Petra Klepac
   email: petra.klepac@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/klepac.petra
+  twitter: petrakle
 - id: mark_jit
   name: Mark Jit
   email: mark.jit@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/jit.mark
 - id: john_edmunds
   name: W John Edmunds
   email: john.edmunds@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/edmunds.john
 - id: amy_gimma
   name: Amy Gimma
   email: amy.gimma@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/gimma.amy
+  twitter: amyg225
 - id: stefan_flasche
   name: Stefan Flasche
   email: stefan.flasche@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/flasche.stefan
+  twitter: StfnFlsch
 - id: billy_quilty
   name: Billy J Quilty
   email: billy.quilty@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/quilty.billy
+  twitter: BQuilty
 - id: sam_clifford
   name: Sam Clifford
   email: sam.clifford@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/clifford.sam
+  twitter: samclifford
 - id: sam_abbott
   name: Sam Abbott
   email: sam.abbott@lshtm.ac.uk
+  url:
+  twitter: seabbs
 - id: james_munday
   name: James D Munday
   email: james.munday@lshtm.ac.uk
+  url:
+  twitter: JDMunday
 - id: nikos_bosse
   name: Nikos I Bosse
   email: nikos.bosse@lshtm.ac.uk
+  url:
+  twitter: ftargument
 - id: joel_hellewell
   name: Joel Hellewell
   email: joel.hellewell@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/hellewell.joel
 - id: hamish_gibbs
   name: Hamish Gibbs
   email: hamish.gibbs@lshtm.ac.uk
+  url:
 - id: yang_liu
   name: Yang Liu
   email: yang.liu@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/liu.yang
+  twitter: yangliubeijing
 - id: nick_davies
   name: Nicholas Davies
   email: nicholas.davies@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/davies.nicholas
+  twitter: _nikdavies
 - id: charlie_diamond
   name: Charlie Diamond
   email: charlie.diamond@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/diamond.charlie
 - id: tim_russell
   name: Timothy W Russell
   email: timothy.russell@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/russell.timothy
+  twitter: realtimothyruss
 - id: chris_jarvis
   name: Christopher I Jarvis
   email: christopher.jarvis@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/jarvis.christopher
+  twitter: jarvis_stats
 - id: kevin_vanzandvoort
   name: Kevin van Zandvoort
   email: kevin.van-zandvoort@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/van-zandvoort.kevin
+  twitter: kevinvzandvoort
 - id: fiona_sun
   name: Fiona Sun
   email: fiona.sun@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/sun.fiona
+  twitter: yueqianfionasun
 - id: alicia_rosello
   name: Alicia Rosello
   email: alicia.rosello@lshtm.ac.uk
+  url:
+  twitter: rmjlros
 - id: carl_ab_pearson
   name: Carl A.B. Pearson
   email: carl.pearson@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/pearson.carl
+  twitter: cap1024
 - id: kiesha_prem
   name: Kiesha Prem
   email: kiesha.prem@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/prem.kiesha
+  twitter: kiesha_prem
 - id: thibaut_jombart
   name: Thibaut Jombart
   email: thibautjombart@gmail.com
+  url:
+  twitter: teebzR
 - id: yung_wai
   name: Yung-Wai Desmond Chan
   email: yung-wai.chan@lshtm.ac.uk
+  url:
 - id: june_chun
   name: June Young Chun
   email: june.y.chun@gmail.com
+  url:
 - id: ruwan_ratnayake
   name: Ruwan Ratnayake
   email: Ruwan.Ratnayake@lshtm.ac.uk
+  url: https://www.lshtm.ac.uk/aboutus/people/ratnayake.ruwan
 - id: robin_thompson
   name: Robin N. Thompson
   email: robin.thompson1988@gmail.com
+  url:
 - id: ncov-group
   name: CMMID nCov working group
   type: group

--- a/_layouts/author_group.html
+++ b/_layouts/author_group.html
@@ -10,7 +10,16 @@ layout: default
 
 <ul>
 {% for author in group_data.members %}
-		{% assign author_data = site.data.authors | where: "id", author | first %}
-		<li>{{ author_data.name }}</li>
+	{% assign author_data = site.data.authors | where: "id", author | first %}
+  <li>
+    {% if author_data.url %}
+      <a href="{{ author_data.url }}">{{ author_data.name }}</a>
+    {% else %}
+		  {{ author_data.name }}
+    {% endif %}
+    {% if author_data.twitter %}
+      (<a href="https://twitter.com/{{ author_data.twitter }}">@{{ author_data.twitter }}</a>)
+    {% endif %}
+  </li>
 {% endfor %}
 </ul>

--- a/_layouts/author_group.html
+++ b/_layouts/author_group.html
@@ -8,7 +8,7 @@ layout: default
 
 <p>The {{ group_data.name }} consists of the following members:</p>
 
-<ul>
+<ul id="author-group">
 {% for author in group_data.members %}
 	{% assign author_data = site.data.authors | where: "id", author | first %}
   <li>
@@ -23,3 +23,10 @@ layout: default
   </li>
 {% endfor %}
 </ul>
+
+<script>
+  var list = document.getElementById("author-group");
+  for (var i = list.children.length; i >= 0; i--) {
+    list.appendChild(list.children[Math.random() * i | 0]);
+  }
+</script>

--- a/_layouts/author_group.html
+++ b/_layouts/author_group.html
@@ -1,17 +1,16 @@
 ---
 layout: default
 ---
-{% assign group_data = site.data.authors | where: "id", page.tag %}
-<h1>{{group_data | map: "name"}}</h1>
+{% assign group_data = site.data.authors | where: "id", page.tag | first %}
+<h1>{{ group_data.name }}</h1>
 
 {{ content }}
 
-<p>The {{group_data | map: "name"}} consists of the following members:</p>
+<p>The {{ group_data.name }} consists of the following members:</p>
 
-{% assign group_members = group_data | map: "members" | remove: '[[' | remove: ']]' | remove: '"' | remove: ' ' | split: ',' %}
 <ul>
-{% for author in group_members %}
-		{% assign author_data = site.data.authors | where: "id", author %}
-		<li>{{ author_data | map: 'name' }}</li>
+{% for author in group_data.members %}
+		{% assign author_data = site.data.authors | where: "id", author | first %}
+		<li>{{ author_data.name }}</li>
 {% endfor %}
 </ul>

--- a/about.md
+++ b/about.md
@@ -5,3 +5,5 @@ permalink: /about/
 ---
 
 The <a href="//cmmid.lshtm.ac.uk" target="_blank">Centre for the Mathematical Modelling of Infectious Diseases</a> (CMMID) at the <a href="//www.lshtm.ac.uk" target="_blank">London School of Hygiene & Tropical Medicine</a> (LSHTM) is a multidisciplinary grouping of epidemiologists, mathematicians, economists, statisticians and clinicians from across all three faculties of LSHTM.
+
+[CMMID nCov working group members]({% link groups/ncov-group.md %})


### PR DESCRIPTION
This set of changes adds links to LSHTM pages and Twitter profiles to the generated author group template (currently only used to generate https://cmmid.github.io/groups/ncov-group).

It also shuffles the order that people are presented on the page, and links to that page from the "about" one.