### PR TITLE
New tags and statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Posts without the status 'accepted' or 'published' will automatically show the "
 To suppress this message, set suppress_peerreviewed: true
 
 ```
-tags: [severity, current-patterns-transmission, control-measures, early-outbreak-dynamics]
+tags: [transmission-dynamics, severity, lmic-considerations, control-measures, mixing-patterns, healthcare-settings, comments-opinions, forecasts-and-projections]
+
 ```
 
 Posts can appear in multiple sections; delete the tags as appropriate
@@ -68,3 +69,13 @@ Detailed instructions:
  5. **DON'T** edit the `---`s.
  6. if using the Github web editing interface, you can check the preview to ensure proper entry. Should see a table-like thing
  7. commit your changes
+
+
+# Adding new tags
+
+To add a new tag, two things are required:
+
+1. a topic page with the `tag_filter` matching that tag (see existing ones for an example)
+2. an entry in `_data/translations.yml` (only the id, matching the tag, and an `en-gb` version are required).
+
+Both of these must be in place before the new tag will be visible on the site.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Front-matter variables are optional, but the following are available:
 ```
 title: Title of the post
 description: Short description of post
-status: in-progress, under-review, or published
+status: paper-under-peer-review, paper-accepted-at-journal, paper-published-at-journal, etc (see template for full list)
 update: YYYY-MM-DD when post was updated
 ```
 
-Posts without the status 'accepted' or 'published' will automatically show the "Ths study is not peer-reviewed" message.
+Posts without the status 'paper-accepted-at-journal' or 'paper-published-at-journal' will automatically show the "Ths study is not peer-reviewed" message.
 To suppress this message, set suppress_peerreviewed: true
 
 ```

--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ defaults:
       type: "posts"
     values:
       layout: "post"
-      status: 'in-progress'
+      status: 'paper-under-peer-review'
   -
     scope:
       path: ""

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -25,6 +25,20 @@
 - id: published
   en-gb: Published
   zh-cn: 已发表
+- id: paper-under-peer-review
+  en-gb: Paper under peer review
+- id: paper-accepted-at-journal
+  en-gb: Paper accepted at journal
+- id: paper-published-at-journal
+  en-gb: Paper published at journal
+- id: real-time-report
+  en-gb: Real time report
+- id: report
+  en-gb: report
+- id: comment-opinion-online
+  en-gb: Comment/Opinion (Online)
+- id: comment-opinion-journal
+  en-gb: Comment/Opinion (Journal)
 - id: corresponding-author
   en-gb: corresponding author
   zh-cn: 通讯作者

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -65,3 +65,15 @@
 - id: current-patterns-transmission
   en-gb: Current patterns of transmission
   zh-cn: 当前传播规律
+- id: transmission-dynamics
+  en-gb: Transmission dynamics
+- id: lmic-considerations
+  en-gb: LMIC considerations
+- id: mixing-patterns
+  en-gb: Mixing patterns
+- id: healthcare-settings
+  en-gb: Healthcare settings
+- id: comments-opinions
+  en-gb: Comments / Opinions
+- id: forecasts-and-projections
+  en-gb: Forecasts and projections

--- a/_layouts/research_post.html
+++ b/_layouts/research_post.html
@@ -11,7 +11,11 @@ layout: full_page_content
 {% unless page.suppress_peerreviewed %}
   {% if post.status != "published" %}
     {% if post.status != "accepted" %}
-      <p><b>{% include fn_translate id="not-peer-reviewed" %}</b></p>
+      {% if post.status != "paper-published-at-journal" %}
+        {% if post.status != "paper-accepted-at-journal" %}
+          <p><b>{% include fn_translate id="not-peer-reviewed" %}</b></p>
+        {% endif %}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endunless %}

--- a/_layouts/research_post.html
+++ b/_layouts/research_post.html
@@ -9,10 +9,10 @@ layout: full_page_content
 {% endif %}
 
 {% unless page.suppress_peerreviewed %}
-  {% if post.status != "published" %}
-    {% if post.status != "accepted" %}
-      {% if post.status != "paper-published-at-journal" %}
-        {% if post.status != "paper-accepted-at-journal" %}
+  {% if page.status != "published" %}
+    {% if page.status != "accepted" %}
+      {% if page.status != "paper-published-at-journal" %}
+        {% if page.status != "paper-accepted-at-journal" %}
           <p><b>{% include fn_translate id="not-peer-reviewed" %}</b></p>
         {% endif %}
       {% endif %}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -86,7 +86,9 @@
       margin-right: 10px;
 
       &.published,
-      &.accepted {
+      &.accepted,
+      &.paper-accepted-at-journal,
+      &.paper-published-at-journal {
         background-color: $color_lshtm_lightblue;
       }
     }

--- a/topics/YYYY-MM-DD-post-template.md
+++ b/topics/YYYY-MM-DD-post-template.md
@@ -6,7 +6,8 @@ title: New project on Covid work#add a description
 description: We evaluated the effectiveness of control measure X for 2019-nCoV infection
 
 # delete any tags which aren't appropriate
-tags: [severity, control-measures, current-patterns-transmission, early-outbreak-dynamics]
+# if you need more tags, they can be created! Please discuss.
+tags: [transmission-dynamics, severity, lmic-considerations, control-measures, mixing-patterns, healthcare-settings, comments-opinions, forecasts-and-projections] 
 
 # add a status: in-progress, under-review, accepted, published
 #defaults to in-progress if not set

--- a/topics/YYYY-MM-DD-post-template.md
+++ b/topics/YYYY-MM-DD-post-template.md
@@ -9,9 +9,15 @@ description: We evaluated the effectiveness of control measure X for 2019-nCoV i
 # if you need more tags, they can be created! Please discuss.
 tags: [transmission-dynamics, severity, lmic-considerations, control-measures, mixing-patterns, healthcare-settings, comments-opinions, forecasts-and-projections] 
 
-# add a status: in-progress, under-review, accepted, published
-#defaults to in-progress if not set
-status: in-progress
+# these are the statuses you can choose from; delete/uncomment as necessary
+# defaults to paper-under-peer-review if not set
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 # add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-02-07

--- a/topics/covid19/_posts/2020-01-28-wuhan-early-dynamics.html
+++ b/topics/covid19/_posts/2020-01-28-wuhan-early-dynamics.html
@@ -3,7 +3,8 @@ title: "Early dynamics of transmission and control of COVID-19 in Wuhan"
 
 description: "To understand how human-to-human transmission varied in Wuhan during the early stages of the 2019-2020 COVID-19 outbreak."
 
-status: accepted
+status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 update: 2020-02-26
 

--- a/topics/covid19/_posts/2020-01-30-airport-screening.md
+++ b/topics/covid19/_posts/2020-01-30-airport-screening.md
@@ -3,7 +3,7 @@ title: Effectiveness of airport screening at detecting travellers infected with 
 
 description: We evaluated effectiveness of thermal passenger screening for 2019-nCoV infection at airport exit and entry to inform public health decision-making.
 
-status: published
+status: paper-published-at-journal
 
 update: 2020-02-07
 

--- a/topics/covid19/_posts/2020-01-30-event-size-vs-duration.md
+++ b/topics/covid19/_posts/2020-01-30-event-size-vs-duration.md
@@ -3,7 +3,9 @@ title: "Understanding the duration and size of the spillover event at the start 
 
 description: "The transmissibility of novel Coronavirus in the early stages of the 2019-20 outbreak in Wuhan: Exploring initial point-source exposure sizes and durations using scenario analysis"
 
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 update: 2020-01-30
 

--- a/topics/covid19/_posts/2020-01-30-reporting-delays-and-temporal-variation-zh-cn.md
+++ b/topics/covid19/_posts/2020-01-30-reporting-delays-and-temporal-variation-zh-cn.md
@@ -3,7 +3,15 @@ title: "报告Covid-19疫情爆发中中国确诊所需时间的延迟和变化"
 
 description: 确定在疫情爆发过程中传染力（再生数）的变化. 本文还未经过同行评审。分析内容将会根据最新数据进行更新。
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 update: 2019-01-30
 

--- a/topics/covid19/_posts/2020-01-30-reporting-delays-and-temporal-variation.md
+++ b/topics/covid19/_posts/2020-01-30-reporting-delays-and-temporal-variation.md
@@ -3,6 +3,16 @@ title: "Reporting delays and temporal variation in transmission in China during 
 
 description: To identify changes in the reproduction number during the course of the outbreak. This analysis will be updated with new data as the epidemic progresses.
 
+# this is a legacy status and should be changed to one of the newer ones
+status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
+
 status: in-progress
 
 update: 2019-01-30

--- a/topics/covid19/_posts/2020-02-07-contact-tracing.md
+++ b/topics/covid19/_posts/2020-02-07-contact-tracing.md
@@ -3,7 +3,7 @@ title: Feasibility of controlling 2019-nCoV outbreaks by isolation of cases and 
 
 description: To assess the viability of isolation and contact tracing to control transmission from imported cases of 2019-nCoV.
 
-status: published
+status: paper-published-at-journal
 
 update: 2020-03-01
 

--- a/topics/covid19/_posts/2020-02-13-screening-outbreak-delay.md
+++ b/topics/covid19/_posts/2020-02-13-screening-outbreak-delay.md
@@ -3,7 +3,9 @@ title: Interventions targeting air travellers early in the pandemic may delay lo
 
 description: To determine if interventions aimed at air travellers can delay establishment of a SARS-CoV-2 outbreak in a previously unaffected country with no shared border with China.
 
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 update: 2020-04-20
 

--- a/topics/covid19/_posts/2020-03-02-pre-symptomatic-transmission.md
+++ b/topics/covid19/_posts/2020-03-02-pre-symptomatic-transmission.md
@@ -3,7 +3,15 @@ title: "The Contribution of Pre-symptomatic Transmission to the COVID-19 Outbrea
 
 description: We estimate the proportion of observed cases that may have been caused by during the pre-symptomatic period of the corresponding primary cases.
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 authors:
 - id: yang_liu

--- a/topics/covid19/_posts/2020-03-03-cases-from-deaths.md
+++ b/topics/covid19/_posts/2020-03-03-cases-from-deaths.md
@@ -5,9 +5,15 @@ title: "Inferring cases from recent deaths"
 
 description: We infer the number of COVID-19 cases based on recently reported deaths. Results suggest that by the time a single COVID-19 death is reported, hundreds to thousands of cases may already be present in the population.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-03-04

--- a/topics/covid19/_posts/2020-03-05-diamond_cruise_cfr_estimates.html
+++ b/topics/covid19/_posts/2020-03-05-diamond_cruise_cfr_estimates.html
@@ -3,7 +3,15 @@ title: "Estimating the infection and case fatality ratio for COVID-19 using age-
 
 description: "Adjusting for delay from confirmation-to-death, we estimated case and infection fatality ratios (CFR, IFR) for COVID-19 on the Diamond Princess ship"
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 rmarkdown_html_fragment: true
 

--- a/topics/covid19/_posts/2020-03-11-overdispersion-from-outbreaksize.md
+++ b/topics/covid19/_posts/2020-03-11-overdispersion-from-outbreaksize.md
@@ -7,9 +7,9 @@ title: Estimating the overdispersion in COVID-19 transmission using outbreak siz
 
 description: We evaluated the overdispersion in the number of secondary transmissions of COVID-19
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-04-15

--- a/topics/covid19/_posts/2020-03-18-social_distancing_wuhan_report.html
+++ b/topics/covid19/_posts/2020-03-18-social_distancing_wuhan_report.html
@@ -3,7 +3,15 @@ title: "The effect of control strategies that reduce social mixing on outcomes o
 
 description: "To assess the impact of a range of control measures that reduce social mixing on data from the COVID-19 outbreak in Wuhan, China."
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 rmarkdown_html_fragment: true
 

--- a/topics/covid19/_posts/2020-03-22-ICU-projections.md
+++ b/topics/covid19/_posts/2020-03-22-ICU-projections.md
@@ -5,9 +5,15 @@ title: "Forecasting critical care bed requirements for COVID-19 patients in Engl
 
 description: We estimate critical care bed demand for COVID-19 cases in England for the next two weeks. Results suggest that current capacity might be reached or exceeded by the end of March 2020.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-03-28

--- a/topics/covid19/_posts/2020-03-22-global_cfr_estimates.html
+++ b/topics/covid19/_posts/2020-03-22-global_cfr_estimates.html
@@ -4,7 +4,15 @@ title: "Using a delay-adjusted case fatality ratio to estimate under-reporting"
 description: "Using a corrected case fatality ratio, we calculate estimates of
 the level of under-reporting for any country with greater than ten deaths"
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 rmarkdown_html_fragment: true
 

--- a/topics/covid19/_posts/2020-03-24-age_hypotheses.md
+++ b/topics/covid19/_posts/2020-03-24-age_hypotheses.md
@@ -5,9 +5,9 @@ title: "Age-dependent effects in the transmission and control of COVID-19 epidem
 
 description: We evaluated hypotheses for the age-distribution of COVID-19 cases reported.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-03-24

--- a/topics/covid19/_posts/2020-03-25-COVID10k-Africa.md
+++ b/topics/covid19/_posts/2020-03-25-COVID10k-Africa.md
@@ -3,7 +3,15 @@ title: Projection of early spread of COVID-19 in Africa
 
 description: We estimate timing of hitting particular case numbers by country in Africa.
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-03-25

--- a/topics/covid19/_posts/2020-03-25-role-of-climate.md
+++ b/topics/covid19/_posts/2020-03-25-role-of-climate.md
@@ -5,9 +5,9 @@ title: Effective transmission across the globe&#58; the role of climate in COVID
 
 description: We discussed the current evidence on the role of climate on COVID-19 transmission.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-03-26

--- a/topics/covid19/_posts/2020-03-31-comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.md
+++ b/topics/covid19/_posts/2020-03-31-comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.md
@@ -5,9 +5,8 @@ title: Impact of physical distance measures on transmission in the UK
 
 description: We present the first results of an ongoing survey (CoMix) to track social contact behaviour during the Covid-19 pandemic, and compare social mixing to patterns found in a previous survey.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: accepted
+status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-04-20

--- a/topics/covid19/_posts/2020-04-01-uk-scenario-modelling.md
+++ b/topics/covid19/_posts/2020-04-01-uk-scenario-modelling.md
@@ -3,7 +3,15 @@ title: "The effect of non-pharmaceutical interventions on COVID-19 cases, deaths
 
 description: We use a stochastic age-structured transmission model to explore a range of COVID-19 intervention scenarios in the UK, including the introduction of school closures, social distancing, shielding of elderly groups, self-isolation of symptomatic cases, and extreme "lockdown"-type restrictions.
 
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 authors:
   - id: nick_davies

--- a/topics/covid19/_posts/2020-04-07-EPI-suspension.md
+++ b/topics/covid19/_posts/2020-04-07-EPI-suspension.md
@@ -3,7 +3,9 @@ title: "Benefit-risk analysis of health benefits of routine childhood immunisati
 
 description: To compare the health benefits of sustaining routine childhood immunisation in Africa against the risk of acquiring SARS-CoV-2 infections through visiting routine vaccination service delivery points.
 
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 update: 2020-04-20
 

--- a/topics/covid19/_posts/2020-04-13-Global_risk_factors.md
+++ b/topics/covid19/_posts/2020-04-13-Global_risk_factors.md
@@ -5,9 +5,9 @@ title: How many are at increased risk of severe COVID-19 disease? Rapid global, 
 
 description: The risk of severe COVID-19 disease is known to be higher in older individuals and those with underlying health conditions. Understanding the number of individuals at increased risk of severe COVID-19 illness, and how this varies between countries is needed to inform the design of possible strategies to shield those at highest risk. We evaluated the global prevalence of underlying conditions associated with severe COVID-19 disease.
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-04-14

--- a/topics/covid19/_posts/2020-04-18-covid-response-strategies-africa.md
+++ b/topics/covid19/_posts/2020-04-18-covid-response-strategies-africa.md
@@ -5,9 +5,15 @@ title: "Response strategies for COVID-19 epidemics in African settings: a mathem
 
 description: "We simulated potential response strategies to assess their effectiveness in three African countries: Niger, Nigeria, and Mauritius."
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
+# this is a legacy status and should be changed to one of the newer ones
 status: in-progress
+# status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
+# status: real-time-report
+# status: report
+# status: comment-opinion-online
+# status: comment-opinion-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-04-19

--- a/topics/covid19/_posts/2020-04-21-wuhan-travel-restrictions.md
+++ b/topics/covid19/_posts/2020-04-21-wuhan-travel-restrictions.md
@@ -5,9 +5,9 @@ title: "The effect of inter-city travel restrictions on geographical spread of C
 
 description: "We evaluated the effectiveness of the cordon sanitaire in Wuhan to delay or prevent outbreaks of COVID-19 in other major cities in mainland China."
 
-#add a status: in-progress, under-review, published
-#defaults to in-progress if not set
-status: under-review
+status: paper-under-peer-review
+# status: paper-accepted-at-journal
+# status: paper-published-at-journal
 
 #add the date at which post is updated (if applicable), in YYYY-MM-DD
 update: 2020-04-21

--- a/topics/covid19/comments-opinions.md
+++ b/topics/covid19/comments-opinions.md
@@ -1,0 +1,5 @@
+---
+tag_filter: comments-opinions
+---
+
+This page list all our comments and opinions

--- a/topics/covid19/epidemiological-dynamics.md
+++ b/topics/covid19/epidemiological-dynamics.md
@@ -1,0 +1,5 @@
+---
+tag_filter: epidemiological-dynamics
+---
+
+This page lists our work on the epidemiological dynamics of Covid-19.

--- a/topics/covid19/forecasts-and-projections.md
+++ b/topics/covid19/forecasts-and-projections.md
@@ -1,0 +1,5 @@
+---
+tag_filter: forecasts-and-projections
+---
+
+This page list all our work on forecasts and projections for Covid-19.

--- a/topics/covid19/healthcare-settings.md
+++ b/topics/covid19/healthcare-settings.md
@@ -1,0 +1,5 @@
+---
+tag_filter: healthcare-settings
+---
+
+This page list all our work on Covid-19 healthcare settings.

--- a/topics/covid19/lmic-considerations.md
+++ b/topics/covid19/lmic-considerations.md
@@ -1,0 +1,5 @@
+---
+tag_filter: lmic-considerations
+---
+
+This page list all our work on Covid-19 in lower & middle income countries

--- a/topics/covid19/mixing-patterns.md
+++ b/topics/covid19/mixing-patterns.md
@@ -1,0 +1,5 @@
+---
+tag_filter: mixing-patterns
+---
+
+This page list all our work on Covid-19 mixing patterns.

--- a/topics/covid19/transmission-dynamics.html
+++ b/topics/covid19/transmission-dynamics.html
@@ -1,0 +1,5 @@
+---
+tag_filter: transmission-dynamics
+---
+
+This page list all our work on transmission dynamics for Covid-19.


### PR DESCRIPTION
This changeset adds new tags/categories, and statuses, which after merging can then be used as post authors are able to. The available tags and statuses are clearly enumerated in the template and README, and where possible, I've made the options obvious in the specific posts too; in most cases, post authors will just need to delete their existing status line and uncomment a new one.

The existing category pages will still be displayed until the last use of the corresponding tag is removed from all posts, at which point it will disappear. When that happens, we will need to redirect visitors from the original category to a suitable new one.